### PR TITLE
Dust recap

### DIFF
--- a/firestone/enUS.json
+++ b/firestone/enUS.json
@@ -321,7 +321,7 @@
 				"click-to-view": "Click to {{link}}",
 				"click-to-view-link": "expand",
 				"duplicate-cards": "{{numberOfCards}} duplicate cards",
-				"dust-potential": "{{dust}} Dust potential"
+				"dust-potential": "+{{dust}} Dust potential"
 			},
 			"card-search": {
 				"search-box-placeholder": "Search card...",


### PR DESCRIPTION
The plus symbol for dust recap amount should not be added via the css file, but should be contained in the source line. I think this is bad programming practice. This is also required for non-English languages.