### PR TITLE
Add sets for BG, mercs & hero skins

### DIFF
--- a/firestone/enUS.json
+++ b/firestone/enUS.json
@@ -43,6 +43,10 @@
 			"region_cn": "China"
 		},
 		"set": {
+			"hero-skins": "-",
+			"lettuce": "Mercenaries",
+			"battlegrounds": "Battlegrounds",
+			"vanilla": "Classic",
 			"legacy": "Legacy",
 			"core": "Core",
 			"naxx": "Curse of Naxxramas",


### PR DESCRIPTION
Add sets for mercenaries, battlegrounds and for hero skins with name "-" as it done on [playhearthstone.com](https://hearthstone.blizzard.com/en-us/cards/2828-magni-bronzebeard/)

![2022-08-19_17-15-28](https://user-images.githubusercontent.com/43519401/185638303-5665119e-5fce-4767-b446-1117e5bd0e15.png)

